### PR TITLE
ADD: `docker prune` commands + `docker image` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ Quick reference guide for Docker commands - not at all exhaustive, just a cheat 
 
 | task | command |
 |:-----|:--------|
-| remove all untagged images | `docker rmi $(docker images \| grep "^<none>" \| awk '{print $3}') ` |
-| remove dangling images | `docker rmi $(docker images -q -f dangling=true) ` |
+| list images | `docker images` |
+| remove specific image(s) | `docker rmi <image_id> <image_id> ...` |
+| remove dangling images | `docker image prune` |
+| remove all unused images | `docker image prune --all` |
+| remove all images | `docker rmi -f $(docker images -q)` |
 
 
 ## Monitoring/Killing Containers
@@ -28,7 +31,7 @@ Quick reference guide for Docker commands - not at all exhaustive, just a cheat 
 | see hash of all containers | `docker ps -aq` | ditto for `-a` and `-q` |
 | kill all running containers | `docker kill $(docker ps -q)` | `kill` only stops running containers |
 | kill most recent container | `docker kill $(docker ps -ql)` |
-| remove all exited containers | `docker rm $(docker ps -qa)` | `rm` only removes exited containers |
+| remove all exited containers | `docker container prune` |
 | remove all containers | `docker rm -f $(docker ps -qa)` | `-f` forces `rm` to kill and remove |
 | remove old containers | `docker ps -a \| grep 'weeks ago' \| awk '{print $1}' \| xargs docker rm` | removes containers that are created weeks ago |
 


### PR DESCRIPTION
Hello,

This PR:
- adds commands to list images, remove specific images, and remove unused images.
- replaces the command to remove dangling images with `docker image prune`. What is the difference between dangling and untagged images? I thought they meant the same thing.
- replaces the command to remove unused containers with `docker container prune`.

Thank you,
Jakub